### PR TITLE
fix_match_last_trip_haul_day_function

### DIFF
--- a/R/2083_match_last_trip_haul_day.R
+++ b/R/2083_match_last_trip_haul_day.R
@@ -1,0 +1,42 @@
+#' Check code: 2083
+#' Check if the last day of a trip and the day of the last haul done
+#' match for a same catch. 
+#' @param df_trips OAB_trips dataframe.
+#' @param df_hauls OAB_hauls dataframe.
+#' @return dataframe with errors.
+
+match_last_trip_haul_day <- function(df_trips, df_hauls){
+
+  df_trips <- unique(df_trips[, c("COD_MAREA", 
+                                  "FECHA_FIN_MAREA")])
+
+  df_trips$FECHA_FIN_MAREA <- as.Date(df_trips$FECHA_FIN_MAREA, 
+                                      format="%d/%m/%Y")
+
+  colnames(df_trips) <- c("COD_MAREA", 
+                          "FECHA_LANCE")
+
+  df_hauls <- unique(df_hauls[, c("COD_MAREA", 
+                                  "FECHA_LANCE")])
+
+  df_hauls$FECHA_LANCE <- as.Date(df_hauls$FECHA_LANCE, 
+                                  format="%d/%m/%Y")
+
+  df_hauls <- df_hauls %>% 
+    group_by(COD_MAREA) %>% 
+    summarise(FECHA_LANCE = max(FECHA_LANCE))
+
+  df_merged <- merge(
+                    df_hauls,
+                    df_trips,
+                    all.x = TRUE
+                    )
+  
+  errors <- df_merged[is.na(df_merged$FECHA_LANCE), ]
+
+  if (nrow(errors) > 0){
+    errors <- addTypeOfError(errors, "WARNING 2083: Last trip and haul day are different for the same catch.")
+    return(errors)
+  }
+
+}

--- a/check_them_all.R
+++ b/check_them_all.R
@@ -110,6 +110,7 @@ check_them_all <- function(){
 
   ERR$pinger_required <- pinger_required()
 
+  ERR$match_last_trip_haul_day <- match_last_trip_haul_day(OAB_trips, OAB_hauls)
 
   # CATCHES
   ERR$catches_empty_fields <- empty_fields_in_variables(OAB_catches, "OAB_CATCHES")

--- a/check_them_all_annual.R
+++ b/check_them_all_annual.R
@@ -119,6 +119,9 @@ check_them_all_annual <- function() {
 
   ERR$pinger_required <- pinger_required()
 
+  ERR$match_last_trip_haul_day <- match_last_trip_haul_day(OAB_trips, OAB_hauls)
+
+
 
   # CATCHES
   ERR$catches_empty_fields <- empty_fields_in_variables(OAB_catches, "OAB_CATCHES")

--- a/oab_post_dump.R
+++ b/oab_post_dump.R
@@ -45,7 +45,7 @@ MONTH <- 9
 # Suffix to path folder (useful when the data of the same month is received
 # in different files). If it is not necessary, use "".
 # FOLDER_SUFFIX <- "b"
-FOLDER_SUFFIX <- "TEST"
+FOLDER_SUFFIX <- ""
 
 # Suffix to add to path. Use only in case MONTH is a vector of months. This
 # suffix will be added to the end of the path with a "_" as separation.
@@ -86,6 +86,7 @@ source("check_them_all.R")
 source("check_them_all_annual.R")
 source("oab_post_dump_speed_plot_functions.R")
 source("R/filter_by_months.R")
+source("R/2083_match_last_trip_haul_day.R")
 
 # GLOBAL VARIABLES -------------------------------------------------------------
 


### PR DESCRIPTION
Done:

- Fix the function "match_last_trip_haul_day_function" and present it again used to check if the last day of a trip and the day of the last haul done match for a same catch. 
- Add it to check_them_all and check_them_all_anual function.

Note:

- The function was stored at "R" directory and, in this version, is called by the line source("R/2083_match_last_trip_haul_day.R") on oab_post_dump.R main script. It is suggested to apply the same guideline used on rim_post_dump scripts for manage oab's functions. 



